### PR TITLE
force compiler to use verilator minimum requirement C++11

### DIFF
--- a/bench/cpp/Makefile
+++ b/bench/cpp/Makefile
@@ -71,7 +71,7 @@
 ##
 ##
 CXX	:= g++
-FLAGS	:= -Wall -Og -g
+FLAGS	:= -Wall -Og -g -std=c++11
 OBJDIR  := obj-pc
 RTLD	:= ../verilog
 VERILATOR_ROOT ?= $(shell bash -c 'verilator -V|grep VERILATOR_ROOT | head -1 | sed -e " s/^.*=\s*//"')
@@ -147,7 +147,7 @@ test: linetest speechtest
 define	build-depends
 	$(mk-objdir)
 	@echo "Building dependency file"
-	@$(CXX) $(CFLAGS) $(INCS) -MM $(SOURCES) > $(OBJDIR)/xdepends.txt
+	@$(CXX) $(FLAGS) $(CFLAGS) $(INCS) -MM $(SOURCES) > $(OBJDIR)/xdepends.txt
 	@sed -e 's/^.*.o: /$(OBJDIR)\/&/' < $(OBJDIR)/xdepends.txt > $(OBJDIR)/depends.txt
 	@rm $(OBJDIR)/xdepends.txt
 endef


### PR DESCRIPTION
to resolve error message: "verilator requires a C++11 or newer compiler", force compiler to use c++11