### PR TITLE
Fix Verilator-reported unused parameters

### DIFF
--- a/bench/verilog/helloworld.v
+++ b/bench/verilog/helloworld.v
@@ -74,7 +74,9 @@ module	helloworld(i_clk,
 	// UART system from a 100MHz clock.  This also sets us to an 8-bit data
 	// word, 1-stop bit, and no parity.  This will be overwritten by
 	// i_setup, but at least it gives us something to start with/from.
+	// verilator lint_off UNUSED
 	parameter	INITIAL_UART_SETUP = 31'd868;
+	// verilator lint_on UNUSED
 
 	// The i_setup wires are input when run under Verilator, but need to
 	// be set internally if this is going to run as a standalone top level

--- a/rtl/txuart.v
+++ b/rtl/txuart.v
@@ -104,9 +104,9 @@ module txuart(i_clk, i_reset, i_setup, i_break, i_wr, i_data,
 	localparam 	[3:0]	TXU_BIT_ONE   = 4'h1;
 	localparam 	[3:0]	TXU_BIT_TWO   = 4'h2;
 	localparam 	[3:0]	TXU_BIT_THREE = 4'h3;
-	localparam 	[3:0]	TXU_BIT_FOUR  = 4'h4;
-	localparam 	[3:0]	TXU_BIT_FIVE  = 4'h5;
-	localparam 	[3:0]	TXU_BIT_SIX   = 4'h6;
+	// localparam 	[3:0]	TXU_BIT_FOUR  = 4'h4;
+	// localparam 	[3:0]	TXU_BIT_FIVE  = 4'h5;
+	// localparam 	[3:0]	TXU_BIT_SIX   = 4'h6;
 	localparam 	[3:0]	TXU_BIT_SEVEN = 4'h7;
 	localparam 	[3:0]	TXU_PARITY    = 4'h8;
 	localparam 	[3:0]	TXU_STOP      = 4'h9;

--- a/rtl/txuartlite.v
+++ b/rtl/txuartlite.v
@@ -80,13 +80,13 @@ module txuartlite #(
 	// Register/net declarations
 	// {{{
 	localparam [3:0]	TXUL_BIT_ZERO  = 4'h0,
-				TXUL_BIT_ONE   = 4'h1,
-				TXUL_BIT_TWO   = 4'h2,
-				TXUL_BIT_THREE = 4'h3,
-				TXUL_BIT_FOUR  = 4'h4,
-				TXUL_BIT_FIVE  = 4'h5,
-				TXUL_BIT_SIX   = 4'h6,
-				TXUL_BIT_SEVEN = 4'h7,
+			//	TXUL_BIT_ONE   = 4'h1,
+			//	TXUL_BIT_TWO   = 4'h2,
+			//	TXUL_BIT_THREE = 4'h3,
+			//	TXUL_BIT_FOUR  = 4'h4,
+			//	TXUL_BIT_FIVE  = 4'h5,
+			//	TXUL_BIT_SIX   = 4'h6,
+			//	TXUL_BIT_SEVEN = 4'h7,
 				TXUL_STOP      = 4'h8,
 				TXUL_IDLE      = 4'hf;
 


### PR DESCRIPTION
Verilator now reports UNUSED parameters/localparams and is failing due to these.

This resolves those issues.  I made assumptions about what should be commented out versus lint-offed versus deleted (nothing), obviously other choices would be reasonable.
