### PR TITLE
Remove tags as part of default make rules

### DIFF
--- a/bench/cpp/Makefile
+++ b/bench/cpp/Makefile
@@ -208,7 +208,7 @@ define	build-depends
 endef
 
 .PHONY: depends
-depends: tags
+depends:
 	$(build-depends)
 
 $(OBJDIR)/depends.txt: depends

--- a/bench/verilog/Makefile
+++ b/bench/verilog/Makefile
@@ -70,7 +70,7 @@
 .PHONY: all
 .DELETE_ON_ERROR:
 ## }}}
-all:	test tags
+all:	test
 ## {{{
 YYMMDD=`date +%Y%m%d`
 CXX   := g++

--- a/rtl/Makefile
+++ b/rtl/Makefile
@@ -41,7 +41,7 @@
 ##
 ## }}}
 .PHONY: all
-all:	test tags
+all:	test
 ## {{{
 .DELETE_ON_ERROR:
 YYMMDD=`date +%Y%m%d`


### PR DESCRIPTION
Remove generating ctags when running tests.
The Verilator extended tests moved to Ubuntu 22.04 and the ctags package slows down the runtime, so this is desired.

Signed-off-by: Wilson Snyder <wsnyder@wsnyder.org>