### PR TITLE
Fixes for Verilator multithreading.

### DIFF
--- a/bench/cpp/Makefile
+++ b/bench/cpp/Makefile
@@ -80,10 +80,13 @@ INCS	:= -I$(RTLD)/obj_dir/ -I$(VROOT)/include
 SOURCES := helloworld.cpp linetest.cpp uartsim.cpp uartsim.h
 VOBJDR	:= $(RTLD)/obj_dir
 SYSVDR	:= $(VROOT)/include
-VSRC	:= verilated.cpp verilated_vcd_c.cpp
-VLIB	:= $(addprefix $(OBJDIR)/,$(subst .cpp,.o,$(VSRC)))
 ## }}}
 all:	$(OBJDIR)/ linetest linetestlite helloworld helloworldlite speechtest speechtestlite test
+
+# Verilator's generated Makefile sets VM_*
+-include $(VOBJDR)/Vlinetest_classes.mk
+VSRC	:= $(addsuffix .cpp, $(VM_GLOBAL_FAST) $(VM_GLOBAL_SLOW))
+VLIB	:= $(addprefix $(OBJDIR)/,$(subst .cpp,.o,$(VSRC)))
 
 $(OBJDIR)/uartsim.o: uartsim.cpp uartsim.h
 

--- a/bench/cpp/linetest.cpp
+++ b/bench/cpp/linetest.cpp
@@ -67,7 +67,6 @@
 
 int	main(int argc, char **argv) {
 	Verilated::commandArgs(argc, argv);
-	SIMCLASS	tb;
 	UARTSIM		*uart;
 	bool		run_interactively = false;
 	int		port = 0;
@@ -96,14 +95,15 @@ int	main(int argc, char **argv) {
 	}
 	// }}}
 
-	// Setup the baud rate
-	// {{{
-	tb.i_setup = setup;
-	int baudclocks = setup & 0x0ffffff;
-	tb.i_uart_rx = 1;
-	// }}}
-
 	if (run_interactively) {
+		// Setup the model and baud rate
+		// {{{
+		SIMCLASS tb;
+		tb.i_setup = setup;
+		tb.i_uart_rx = 1;
+		// }}}
+
+
 		// {{{
 		uart = new UARTSIM(port);
 		uart->setup(tb.i_setup);
@@ -216,6 +216,14 @@ int	main(int argc, char **argv) {
 				perror("O/S ERR");
 				exit(EXIT_FAILURE);
 			}
+
+			// Setup the model and baud rate
+			// {{{
+			SIMCLASS tb;
+			tb.i_setup = setup;
+			int baudclocks = setup & 0x0ffffff;
+			tb.i_uart_rx = 1;
+			// }}}
 
 			// UARTSIM(0) uses stdin and stdout for its FD's
 			uart = new UARTSIM(0);


### PR DESCRIPTION
Verilator now defaults to having multithreading support.  I'd appreciate your considering these fixes.

1. This changes the makefile to avoid a compile error, as verilated_threads needs to be compiled in.  This changes the makefile to use the files Verilator itself suggests.

2. After the model runs the model destructor was hanging, this was because it was made before a fork, so there was a copy in each process. This instead makes the model after the fork.


