### PR TITLE
Remove Makefile -std=c++11

### DIFF
--- a/bench/cpp/Makefile
+++ b/bench/cpp/Makefile
@@ -71,7 +71,7 @@
 ##
 ##
 CXX	:= g++
-FLAGS	:= -std=c++11 -Wall -Og -g
+FLAGS	:= -Wall -Og -g
 OBJDIR  := obj-pc
 RTLD	:= ../verilog
 VERILATOR_ROOT ?= $(shell bash -c 'verilator -V|grep VERILATOR_ROOT | head -1 | sed -e " s/^.*=\s*//"')


### PR DESCRIPTION
Verilator is still using wbuart32 as part of its regressions.

Verilator is now using some C++14 constructs, so this commit from 2020, issue #8, which requests C++11, breaks the Verilator regression.

If running on a distro from the last 4 years or so (Ubuntu 20.04 newer), this flag shouldn't be needed, so I'm proposing removing it.

Another possibility is to ask for -std=c++14 but this will need updating again in a few years.